### PR TITLE
Resolve laravel-mfa package stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
   },
   "minimum-stability": "stable",
   "prefer-stable": true
-  ,
-  "version": "1.0.0"
+  
 }
 


### PR DESCRIPTION
Remove `version` field from `composer.json` to enable proper stable release tagging via Git.

This change is part of a larger fix to allow the package to be recognized as stable by Packagist. Packagist prefers to derive package versions from Git tags rather than a static `version` field in `composer.json`. Removing this field, in conjunction with pushing a `v1.0.0` Git tag, allows the package to be installed by consumers with `minimum-stability: stable`.

---
<a href="https://cursor.com/background-agent?bcId=bc-94b2b69e-bc6d-4d24-92b7-b3e44520977a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94b2b69e-bc6d-4d24-92b7-b3e44520977a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

