### PR TITLE
Add Laravel 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 Multi Factor Authentication
 CodingLibs Laravel MFA
 
+Compatibility
+- Laravel 11 and 12
+- PHP >= 8.2
+
 Installation
 - Install via Composer from Packagist:
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "codinglibs/laravel-mfa",
-  "description": "Laravel 12 Multi-Factor Authentication package (Email, SMS, Google Authenticator TOTP)",
+  "description": "Laravel 11/12 Multi-Factor Authentication package (Email, SMS, Google Authenticator TOTP)",
   "type": "library",
   "license": "MIT",
   "authors": [
@@ -11,11 +11,11 @@
   ],
   "require": {
     "php": ">=8.2",
-    "illuminate/support": "^12.0",
-    "illuminate/database": "^12.0",
-    "illuminate/mail": "^12.0",
-    "illuminate/config": "^12.0",
-    "illuminate/console": "^12.0",
+    "illuminate/support": "^11.0|^12.0",
+    "illuminate/database": "^11.0|^12.0",
+    "illuminate/mail": "^11.0|^12.0",
+    "illuminate/config": "^11.0|^12.0",
+    "illuminate/console": "^11.0|^12.0",
     "bacon/bacon-qr-code": "^2.0"
   },
   "autoload": {


### PR DESCRIPTION
Add support for Laravel 11 by updating `composer.json` constraints and `README.md`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed45d92d-eab2-4b0b-a40c-39046b5979e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ed45d92d-eab2-4b0b-a40c-39046b5979e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

