### PR TITLE
Clarify ternary operator precedence

### DIFF
--- a/src/MFA.php
+++ b/src/MFA.php
@@ -37,7 +37,7 @@ class MFA
     {
         $secret = GoogleTotp::generateSecret();
         $issuer = $issuer ?: Arr::get($this->config, 'totp.issuer', 'Laravel');
-        $label = $label ?: method_exists($user, 'getEmailForVerification') ? $user->getEmailForVerification() : ($user->email ?? (string) $user->getAuthIdentifier());
+        $label = $label ?: (method_exists($user, 'getEmailForVerification') ? $user->getEmailForVerification() : ($user->email ?? (string) $user->getAuthIdentifier()));
         $otpauth = GoogleTotp::buildOtpAuthUrl($secret, $label, $issuer, Arr::get($this->config, 'totp.digits', 6));
 
         $this->enableMethod($user, 'totp', ['secret' => $secret]);


### PR DESCRIPTION
Add parentheses to an ambiguous nested ternary expression to resolve a PHP parsing error.

---
<a href="https://cursor.com/background-agent?bcId=bc-3320532a-ac6e-411c-b12a-58a27ff94de9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3320532a-ac6e-411c-b12a-58a27ff94de9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

