### PR TITLE
Fix missing png renderer class

### DIFF
--- a/src/Support/QrCodeGenerator.php
+++ b/src/Support/QrCodeGenerator.php
@@ -3,7 +3,9 @@
 namespace CodingLibs\MFA\Support;
 
 use BaconQrCode\Renderer\Color\Rgb;
-use BaconQrCode\Renderer\Image\Png;
+use BaconQrCode\Renderer\ImageRenderer;
+use BaconQrCode\Renderer\Image\GdImageBackEnd;
+use BaconQrCode\Renderer\Image\ImagickImageBackEnd;
 use BaconQrCode\Renderer\Module\SquareModule;
 use BaconQrCode\Renderer\RendererStyle\Fill;
 use BaconQrCode\Renderer\RendererStyle\RendererStyle;
@@ -13,7 +15,7 @@ class QrCodeGenerator
 {
     public static function generateBase64Png(string $text, int $size = 200): string
     {
-        $renderer = new Png(
+        $renderer = new ImageRenderer(
             new RendererStyle(
                 $size,
                 0,
@@ -21,12 +23,26 @@ class QrCodeGenerator
                 null,
                 Fill::uniformColor(new Rgb(255, 255, 255), new Rgb(0, 0, 0)),
                 new SquareModule()
-            )
+            ),
+            self::selectImageBackEnd()
         );
 
         $writer = new Writer($renderer);
         $pngData = $writer->writeString($text);
         return 'data:image/png;base64,' . base64_encode($pngData);
+    }
+
+    private static function selectImageBackEnd()
+    {
+        if (class_exists(\Imagick::class)) {
+            return new ImagickImageBackEnd();
+        }
+
+        if (extension_loaded('gd')) {
+            return new GdImageBackEnd();
+        }
+
+        throw new \RuntimeException('No image backend available: install Imagick or enable GD.');
     }
 }
 


### PR DESCRIPTION
Update QR code generator to use `ImageRenderer` with dynamic backend to resolve "Class not found" error.

The `BaconQrCode\Renderer\Image\Png` class was removed in `bacon/bacon-qr-code` v2/v3. This change updates `QrCodeGenerator::generateBase64Png` to use `ImageRenderer` with an automatic backend selection (Imagick if available, otherwise GD), ensuring compatibility with newer versions of the library while preserving existing styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-f13abed3-e509-4b36-b32c-f79c736cbf2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f13abed3-e509-4b36-b32c-f79c736cbf2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

