### PR TITLE
Call private squaremodule constructor from qrcodegenerator

### DIFF
--- a/src/Support/QrCodeGenerator.php
+++ b/src/Support/QrCodeGenerator.php
@@ -22,7 +22,7 @@ class QrCodeGenerator
                 null,
                 null,
                 Fill::uniformColor(new Rgb(255, 255, 255), new Rgb(0, 0, 0)),
-                new SquareModule()
+                SquareModule::instance()
             ),
             self::selectImageBackEnd()
         );


### PR DESCRIPTION
Fix `BaconQrCode\Renderer\Module\SquareModule` instantiation by using its singleton `instance()` method because its constructor is private.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2003781-cdf8-4af1-9b21-d40cd6d62c16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e2003781-cdf8-4af1-9b21-d40cd6d62c16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

