### PR TITLE
Require hyphenated laravel mfa package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Compatibility
 Installation
 - Install via Composer from Packagist:
 ```
-composer require codinglibs/laravel-mfa
+composer require coding-libs/laravel-mfa
 ```
 - The service provider auto-registers. Publish config and migrations:
 ```
@@ -19,7 +19,7 @@ php artisan migrate
 ```
 
 Packagist
-- `https://packagist.org/packages/codinglibs/laravel-mfa`
+- `https://packagist.org/packages/coding-libs/laravel-mfa`
 
 Usage
 ```php

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "codinglibs/laravel-mfa",
+  "name": "coding-libs/laravel-mfa",
   "description": "Laravel Multi-Factor Authentication package (Email, SMS, Google Authenticator TOTP)",
   "type": "library",
   "license": "MIT",


### PR DESCRIPTION
Correct package name from `codinglibs/laravel-mfa` to `coding-libs/laravel-mfa` in `composer.json` and `README.md`.

---
<a href="https://cursor.com/background-agent?bcId=bc-33f70cd4-0e64-42cb-b6e0-18a918a1d0c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-33f70cd4-0e64-42cb-b6e0-18a918a1d0c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

