### PR TITLE
Remember device after verification

### DIFF
--- a/config/mfa.php
+++ b/config/mfa.php
@@ -23,5 +23,16 @@ return [
         'period' => (int)env('MFA_TOTP_PERIOD', 30),
         'window' => (int)env('MFA_TOTP_WINDOW', 1),
     ],
+
+    'remember' => [
+        'enabled'        => env('MFA_REMEMBER_ENABLED', true),
+        'cookie'         => env('MFA_REMEMBER_COOKIE', 'mfa_rd'),
+        'lifetime_days'  => (int) env('MFA_REMEMBER_LIFETIME_DAYS', 30),
+        'path'           => env('MFA_REMEMBER_PATH', '/'),
+        'domain'         => env('MFA_REMEMBER_DOMAIN', null),
+        'secure'         => env('MFA_REMEMBER_SECURE', null), // null to follow app('request')->isSecure()
+        'http_only'      => env('MFA_REMEMBER_HTTP_ONLY', true),
+        'same_site'      => env('MFA_REMEMBER_SAME_SITE', 'lax'), // lax|strict|none
+    ],
 ];
 

--- a/database/migrations/create_mfa_remembered_devices_table.php
+++ b/database/migrations/create_mfa_remembered_devices_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('mfa_remembered_devices', function (Blueprint $table) {
+            $table->id();
+            $table->string('user_type');
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('token_hash', 64);
+            $table->string('device_name')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at');
+            $table->timestamps();
+
+            $table->unique(['user_type', 'user_id', 'token_hash'], 'mfa_rd_unique');
+            $table->index(['user_type', 'user_id'], 'mfa_rd_user_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mfa_remembered_devices');
+    }
+};
+

--- a/src/MFAServiceProvider.php
+++ b/src/MFAServiceProvider.php
@@ -27,8 +27,10 @@ class MFAServiceProvider extends ServiceProvider
 
         if (! class_exists('CreateMfaTables')) {
             $timestamp = date('Y_m_d_His');
+            $timestamp2 = date('Y_m_d_His', time() + 1);
             $this->publishes([
                 __DIR__ . '/../database/migrations/create_mfa_tables.php' => database_path("migrations/{$timestamp}_create_mfa_tables.php"),
+                __DIR__ . '/../database/migrations/create_mfa_remembered_devices_table.php' => database_path("migrations/{$timestamp2}_create_mfa_remembered_devices_table.php"),
             ], 'mfa-migrations');
         }
     }

--- a/src/Models/MfaRememberedDevice.php
+++ b/src/Models/MfaRememberedDevice.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace CodingLibs\MFA\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MfaRememberedDevice extends Model
+{
+    protected $table = 'mfa_remembered_devices';
+
+    protected $guarded = [];
+}
+


### PR DESCRIPTION
Add "Remember this device" functionality for MFA to allow users to skip verification on trusted devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2eca18b-2f4a-4893-ac22-4904be28a0ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2eca18b-2f4a-4893-ac22-4904be28a0ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

