### PR TITLE
Add user agent and remember devices table

### DIFF
--- a/database/migrations/create_mfa_remembered_devices_table.php
+++ b/database/migrations/create_mfa_remembered_devices_table.php
@@ -13,6 +13,7 @@ return new class extends Migration {
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('token_hash', 64);
             $table->string('device_name')->nullable();
+            $table->text('user_agent')->nullable();
             $table->timestamp('last_used_at')->nullable();
             $table->timestamp('expires_at');
             $table->timestamps();

--- a/src/MFA.php
+++ b/src/MFA.php
@@ -183,6 +183,11 @@ class MFA
         }
 
         $record->last_used_at = $now;
+        // Optional: update the stored user agent when we see the device again
+        $request = app('request');
+        if ($request instanceof \Illuminate\Http\Request) {
+            $record->user_agent = (string) $request->userAgent();
+        }
         $record->save();
 
         return true;
@@ -205,6 +210,10 @@ class MFA
         $record->user_id = $user->getAuthIdentifier();
         $record->token_hash = $hash;
         $record->device_name = $deviceName;
+        $request = app('request');
+        if ($request instanceof \Illuminate\Http\Request) {
+            $record->user_agent = (string) $request->userAgent();
+        }
         $record->expires_at = $expiresAt;
         $record->last_used_at = Carbon::now();
         $record->save();


### PR DESCRIPTION
Add `user_agent` field to remembered devices to track the user agent when a device is remembered or reused.

---
<a href="https://cursor.com/background-agent?bcId=bc-74f2b1f7-abd6-4d76-9f1f-3366cc125929">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74f2b1f7-abd6-4d76-9f1f-3366cc125929">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

