### PR TITLE
Add IP field to remember_devices

### DIFF
--- a/database/migrations/2025_01_01_000001_add_ip_to_mfa_remembered_devices_table.php
+++ b/database/migrations/2025_01_01_000001_add_ip_to_mfa_remembered_devices_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('mfa_remembered_devices', function (Blueprint $table) {
+            $table->string('ip_address', 45)->nullable()->after('token_hash');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('mfa_remembered_devices', function (Blueprint $table) {
+            $table->dropColumn('ip_address');
+        });
+    }
+};

--- a/database/migrations/create_mfa_remembered_devices_table.php
+++ b/database/migrations/create_mfa_remembered_devices_table.php
@@ -12,6 +12,7 @@ return new class extends Migration {
             $table->string('user_type');
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('token_hash', 64);
+            $table->string('ip_address', 45)->nullable();
             $table->string('device_name')->nullable();
             $table->text('user_agent')->nullable();
             $table->timestamp('last_used_at')->nullable();

--- a/src/MFAServiceProvider.php
+++ b/src/MFAServiceProvider.php
@@ -28,9 +28,11 @@ class MFAServiceProvider extends ServiceProvider
         if (! class_exists('CreateMfaTables')) {
             $timestamp = date('Y_m_d_His');
             $timestamp2 = date('Y_m_d_His', time() + 1);
+            $timestamp3 = date('Y_m_d_His', time() + 2);
             $this->publishes([
                 __DIR__ . '/../database/migrations/create_mfa_tables.php' => database_path("migrations/{$timestamp}_create_mfa_tables.php"),
                 __DIR__ . '/../database/migrations/create_mfa_remembered_devices_table.php' => database_path("migrations/{$timestamp2}_create_mfa_remembered_devices_table.php"),
+                __DIR__ . '/../database/migrations/2025_01_01_000001_add_ip_to_mfa_remembered_devices_table.php' => database_path("migrations/{$timestamp3}_add_ip_to_mfa_remembered_devices_table.php"),
             ], 'mfa-migrations');
         }
     }


### PR DESCRIPTION
Add an `ip_address` column to the `mfa_remembered_devices` table to track the IP from which a device was remembered.

---
<a href="https://cursor.com/background-agent?bcId=bc-1435cf6a-b320-4161-bcfb-2876be04252f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1435cf6a-b320-4161-bcfb-2876be04252f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

