### PR TITLE
Implement configurable polymorphic relations

### DIFF
--- a/config/mfa.php
+++ b/config/mfa.php
@@ -42,5 +42,21 @@ return [
         'regenerate_on_use'  => env('MFA_RECOVERY_REGENERATE_ON_USE', false),
         'hash_algo'          => env('MFA_RECOVERY_HASH_ALGO', 'sha256'),
     ],
+
+    // Polymorphic owner of MFA records: columns will be model_type/model_id
+    'morph' => [
+        // Column name prefix; results in `${name}_type` and `${name}_id`
+        'name'           => env('MFA_MORPH_NAME', 'model'),
+
+        // ID column type for `${name}_id`.
+        // Supported: unsignedBigInteger (default) | unsignedInteger | bigInteger | integer | string | uuid | ulid
+        'type'           => env('MFA_MORPH_TYPE', 'unsignedBigInteger'),
+
+        // Length for `${name}_id` when type is "string"
+        'string_length'  => (int) env('MFA_MORPH_STRING_LENGTH', 40),
+
+        // Length for `${name}_type` column
+        'type_length'    => (int) env('MFA_MORPH_TYPE_LENGTH', 255),
+    ],
 ];
 

--- a/database/migrations/create_mfa_tables.php
+++ b/database/migrations/create_mfa_tables.php
@@ -9,32 +9,125 @@ return new class extends Migration {
     {
         Schema::create('mfa_methods', function (Blueprint $table) {
             $table->id();
-            $table->string('user_type');
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $morph = config('mfa.morph', []);
+            $morphName = $morph['name'] ?? 'model';
+            $typeColumn = $morphName . '_type';
+            $idColumn = $morphName . '_id';
+            $typeLength = (int) ($morph['type_length'] ?? 255);
+            $idType = $morph['type'] ?? 'unsignedBigInteger';
+            $idStringLength = (int) ($morph['string_length'] ?? 40);
+
+            $table->string($typeColumn, $typeLength);
+            switch ($idType) {
+                case 'unsignedInteger':
+                    $table->unsignedInteger($idColumn);
+                    break;
+                case 'bigInteger':
+                    $table->bigInteger($idColumn);
+                    break;
+                case 'integer':
+                    $table->integer($idColumn);
+                    break;
+                case 'string':
+                    $table->string($idColumn, $idStringLength);
+                    break;
+                case 'uuid':
+                    $table->uuid($idColumn);
+                    break;
+                case 'ulid':
+                    $table->ulid($idColumn);
+                    break;
+                case 'unsignedBigInteger':
+                default:
+                    $table->unsignedBigInteger($idColumn);
+                    break;
+            }
             $table->string('method'); // email|sms|totp
             $table->text('secret')->nullable(); // for totp
             $table->timestamp('enabled_at')->nullable();
             $table->timestamp('last_used_at')->nullable();
             $table->timestamps();
-            $table->index(['user_type', 'user_id', 'method']);
+            $table->index([$typeColumn, $idColumn, 'method']);
         });
 
         Schema::create('mfa_challenges', function (Blueprint $table) {
             $table->id();
-            $table->string('user_type');
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $morph = config('mfa.morph', []);
+            $morphName = $morph['name'] ?? 'model';
+            $typeColumn = $morphName . '_type';
+            $idColumn = $morphName . '_id';
+            $typeLength = (int) ($morph['type_length'] ?? 255);
+            $idType = $morph['type'] ?? 'unsignedBigInteger';
+            $idStringLength = (int) ($morph['string_length'] ?? 40);
+
+            $table->string($typeColumn, $typeLength);
+            switch ($idType) {
+                case 'unsignedInteger':
+                    $table->unsignedInteger($idColumn);
+                    break;
+                case 'bigInteger':
+                    $table->bigInteger($idColumn);
+                    break;
+                case 'integer':
+                    $table->integer($idColumn);
+                    break;
+                case 'string':
+                    $table->string($idColumn, $idStringLength);
+                    break;
+                case 'uuid':
+                    $table->uuid($idColumn);
+                    break;
+                case 'ulid':
+                    $table->ulid($idColumn);
+                    break;
+                case 'unsignedBigInteger':
+                default:
+                    $table->unsignedBigInteger($idColumn);
+                    break;
+            }
             $table->string('method'); // email|sms
             $table->string('code');
             $table->timestamp('expires_at');
             $table->timestamp('consumed_at')->nullable();
             $table->timestamps();
-            $table->index(['user_type', 'user_id', 'method']);
+            $table->index([$typeColumn, $idColumn, 'method']);
         });
 
         Schema::create('mfa_remembered_devices', function (Blueprint $table) {
             $table->id();
-            $table->string('user_type');
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $morph = config('mfa.morph', []);
+            $morphName = $morph['name'] ?? 'model';
+            $typeColumn = $morphName . '_type';
+            $idColumn = $morphName . '_id';
+            $typeLength = (int) ($morph['type_length'] ?? 255);
+            $idType = $morph['type'] ?? 'unsignedBigInteger';
+            $idStringLength = (int) ($morph['string_length'] ?? 40);
+
+            $table->string($typeColumn, $typeLength);
+            switch ($idType) {
+                case 'unsignedInteger':
+                    $table->unsignedInteger($idColumn);
+                    break;
+                case 'bigInteger':
+                    $table->bigInteger($idColumn);
+                    break;
+                case 'integer':
+                    $table->integer($idColumn);
+                    break;
+                case 'string':
+                    $table->string($idColumn, $idStringLength);
+                    break;
+                case 'uuid':
+                    $table->uuid($idColumn);
+                    break;
+                case 'ulid':
+                    $table->ulid($idColumn);
+                    break;
+                case 'unsignedBigInteger':
+                default:
+                    $table->unsignedBigInteger($idColumn);
+                    break;
+            }
             $table->string('token_hash', 64);
             $table->string('ip_address', 45)->nullable();
             $table->string('device_name')->nullable();
@@ -43,19 +136,50 @@ return new class extends Migration {
             $table->timestamp('expires_at');
             $table->timestamps();
 
-            $table->unique(['user_type', 'user_id', 'token_hash'], 'mfa_rd_unique');
-            $table->index(['user_type', 'user_id'], 'mfa_rd_user_idx');
+            $table->unique([$typeColumn, $idColumn, 'token_hash'], 'mfa_rd_unique');
+            $table->index([$typeColumn, $idColumn], 'mfa_rd_user_idx');
         });
 
         Schema::create('mfa_recovery_codes', function (Blueprint $table) {
             $table->id();
-            $table->string('user_type');
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $morph = config('mfa.morph', []);
+            $morphName = $morph['name'] ?? 'model';
+            $typeColumn = $morphName . '_type';
+            $idColumn = $morphName . '_id';
+            $typeLength = (int) ($morph['type_length'] ?? 255);
+            $idType = $morph['type'] ?? 'unsignedBigInteger';
+            $idStringLength = (int) ($morph['string_length'] ?? 40);
+
+            $table->string($typeColumn, $typeLength);
+            switch ($idType) {
+                case 'unsignedInteger':
+                    $table->unsignedInteger($idColumn);
+                    break;
+                case 'bigInteger':
+                    $table->bigInteger($idColumn);
+                    break;
+                case 'integer':
+                    $table->integer($idColumn);
+                    break;
+                case 'string':
+                    $table->string($idColumn, $idStringLength);
+                    break;
+                case 'uuid':
+                    $table->uuid($idColumn);
+                    break;
+                case 'ulid':
+                    $table->ulid($idColumn);
+                    break;
+                case 'unsignedBigInteger':
+                default:
+                    $table->unsignedBigInteger($idColumn);
+                    break;
+            }
             $table->string('code_hash', 128);
             $table->timestamp('used_at')->nullable();
             $table->timestamps();
 
-            $table->index(['user_type', 'user_id'], 'mfa_rc_user_idx');
+            $table->index([$typeColumn, $idColumn], 'mfa_rc_user_idx');
         });
     }
 

--- a/src/Models/MfaChallenge.php
+++ b/src/Models/MfaChallenge.php
@@ -14,5 +14,12 @@ class MfaChallenge extends Model
         'expires_at' => 'datetime',
         'consumed_at' => 'datetime',
     ];
+
+    public function model()
+    {
+        $morph = config('mfa.morph', []);
+        $name = $morph['name'] ?? 'model';
+        return $this->morphTo(__FUNCTION__, $name . '_type', $name . '_id');
+    }
 }
 

--- a/src/Models/MfaMethod.php
+++ b/src/Models/MfaMethod.php
@@ -15,5 +15,12 @@ class MfaMethod extends Model
         'last_used_at' => 'datetime',
         'secret' => 'encrypted',
     ];
+
+    public function model()
+    {
+        $morph = config('mfa.morph', []);
+        $name = $morph['name'] ?? 'model';
+        return $this->morphTo(__FUNCTION__, $name . '_type', $name . '_id');
+    }
 }
 

--- a/src/Models/MfaRecoveryCode.php
+++ b/src/Models/MfaRecoveryCode.php
@@ -13,5 +13,12 @@ class MfaRecoveryCode extends Model
     protected $casts = [
         'used_at' => 'datetime',
     ];
+
+    public function model()
+    {
+        $morph = config('mfa.morph', []);
+        $name = $morph['name'] ?? 'model';
+        return $this->morphTo(__FUNCTION__, $name . '_type', $name . '_id');
+    }
 }
 

--- a/src/Models/MfaRememberedDevice.php
+++ b/src/Models/MfaRememberedDevice.php
@@ -14,5 +14,12 @@ class MfaRememberedDevice extends Model
         'last_used_at' => 'datetime',
         'expires_at' => 'datetime',
     ];
+
+    public function model()
+    {
+        $morph = config('mfa.morph', []);
+        $name = $morph['name'] ?? 'model';
+        return $this->morphTo(__FUNCTION__, $name . '_type', $name . '_id');
+    }
 }
 


### PR DESCRIPTION
Replace hardcoded `user_type`/`user_id` columns with configurable polymorphic `model_type`/`model_id` to support diverse owner models and ID types.

---
<a href="https://cursor.com/background-agent?bcId=bc-47aef492-31f3-4a14-b0bf-b19165f62c9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47aef492-31f3-4a14-b0bf-b19165f62c9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

